### PR TITLE
chore(deps): update default registry's baseline to `b7a701cb475805c27e29ddf635a3b16c37ba51fb`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "65be7019941e1401e02daaba0738cab2c8a4a355"
+      "baseline": "b7a701cb475805c27e29ddf635a3b16c37ba51fb"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `b7a701cb475805c27e29ddf635a3b16c37ba51fb`.