### PR TITLE
chore(deps): update default registry's baseline to `d5ec528843d29e3a52d745a64b469f810b2cedbf`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "b7a701cb475805c27e29ddf635a3b16c37ba51fb"
+      "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `d5ec528843d29e3a52d745a64b469f810b2cedbf`.