### PR TITLE
chore(deps): update default registry's baseline to `b02e341c927f16d991edbd915d8ea43eac52096c`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vcpkg"]
 	path = vcpkg
 	url = https://github.com/microsoft/vcpkg.git
-	branch = 2025.02.14
+	branch = 2025.03.19

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+      "baseline": "b02e341c927f16d991edbd915d8ea43eac52096c"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `b02e341c927f16d991edbd915d8ea43eac52096c`.