### PR TITLE
chore(deps): update default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+      "baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`.