### PR TITLE
chore(deps): update default registry's baseline to `ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+      "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0`.