### PR TITLE
chore(deps): update default registry's baseline to `120deac3062162151622ca4860575a33844ba10b`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
+      "baseline": "120deac3062162151622ca4860575a33844ba10b"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `120deac3062162151622ca4860575a33844ba10b`.