### PR TITLE
chore(deps): update default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "120deac3062162151622ca4860575a33844ba10b"
+      "baseline": "4334d8b4c8916018600212ab4dd4bbdc343065d1"
     },
     "registries": [
       {


### PR DESCRIPTION
This PR updates default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`.